### PR TITLE
Add 'users_no_inprocess' to request.php

### DIFF
--- a/public_html/api/api_cod/request.php
+++ b/public_html/api/api_cod/request.php
@@ -33,6 +33,7 @@ $other_tables = [
     'enwiki_pageviews',
     'categories',
     'full_translators',
+    'users_no_inprocess',
     'projects',
     'settings',
     'translate_type',
@@ -53,9 +54,14 @@ $execution_time = 0;
 
 $select_valids = [
     'count(title) as count',
+    'count(p.title) as count',
     'YEAR(date) AS year',
+    'YEAR(p.date) AS year',
     'YEAR(pupdate) AS year',
+    'YEAR(p.pupdate) AS year',
     'lang',
+    'p.lang',
+    'p.user',
     'user',
 ];
 

--- a/public_html/api/endpointGroups.json
+++ b/public_html/api/endpointGroups.json
@@ -30,6 +30,7 @@
         "users_by_wiki",
         "users_by_last_pupdate",
         "full_translators",
+        "users_no_inprocess",
         "coordinator"
     ],
     "statistics": [

--- a/public_html/api/endpoint_params.json
+++ b/public_html/api/endpoint_params.json
@@ -219,6 +219,10 @@
         "params": [
         ]
     },
+    "users_no_inprocess": {
+        "params": [
+        ]
+    },
     "full_translators": {
         "params": [
         ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for the "users_no_inprocess" endpoint in the API, allowing users to make requests to this new endpoint.
	- Expanded selectable fields for certain API queries, enabling new options such as selecting counts, years, language, and user information from page-related data.
- **Documentation**
	- Updated API documentation to include the new "users_no_inprocess" endpoint and its parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->