### PR TITLE
add offset to API results

### DIFF
--- a/generate-key.php
+++ b/generate-key.php
@@ -1,12 +1,23 @@
 <?php
 
-require_once('Translation_Dashboard/vendor/autoload.php');
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
+
+include_once __DIR__ . '/../auth/vendor_load.php';
 
 use Defuse\Crypto\Key;
 
-if (file_exists('mdwiki-secret-key.txt')) {
+$file = __DIR__ . '/mdwiki-secret-key.txt';
+
+echo "$file\n";
+
+if (file_exists($file)) {
     die('Key already exists, will not overwrite.');
 }
+
 $key = Key::createNewRandomKey();
-file_put_contents('mdwiki-secret-key.txt', $key->saveToAsciiSafeString());
-chmod('mdwiki-secret-key.txt', 0600);
+
+file_put_contents($file, $key->saveToAsciiSafeString());
+
+chmod($file, 0600);

--- a/public_html/api/api_cod/helps.php
+++ b/public_html/api/api_cod/helps.php
@@ -7,6 +7,7 @@ use function API\Helps\sanitize_input;
 use function API\Helps\add_order;
 use function API\Helps\add_group;
 use function API\Helps\add_limit;
+use function API\Helps\add_offset;
 use function API\Helps\add_li_params;
 */
 
@@ -41,13 +42,29 @@ function add_order($qua)
     }
     return $qua;
 }
+function add_offset($qua)
+{
+    // if $qua has OFFSET then return
+    if (strpos($qua, 'OFFSET') !== false || strpos($qua, 'offset') !== false) return $qua;
+    if (isset($_GET['offset'])) {
+        $added = filter_input(INPUT_GET, 'offset', FILTER_SANITIZE_SPECIAL_CHARS);
+        $added = (int) $added;
+        if ($added > 0) {
+            $qua .= " OFFSET $added";
+        }
+    }
+    return $qua;
+}
 function add_limit($qua)
 {
     // if $qua has LIMIT then return
     if (strpos($qua, 'LIMIT') !== false || strpos($qua, 'limit') !== false) return $qua;
     if (isset($_GET['limit'])) {
         $added = filter_input(INPUT_GET, 'limit', FILTER_SANITIZE_SPECIAL_CHARS);
-        $qua .= " LIMIT $added";
+        $added = (int) $added;
+        if ($added > 0) {
+            $qua .= " LIMIT $added";
+        }
     }
     return $qua;
 }

--- a/public_html/api/api_cod/request.php
+++ b/public_html/api/api_cod/request.php
@@ -54,6 +54,8 @@ $results = [];
 $execution_time = 0;
 
 $select_valids = [
+    'COUNT(*) as count',
+    'count(*) as count',
     'count(title) as count',
     'count(p.title) as count',
     'YEAR(date) AS year',
@@ -66,11 +68,16 @@ $select_valids = [
     'user',
 ];
 
-$SELECT = (isset($_GET['select'])) ? filter_input(INPUT_GET, 'select', FILTER_SANITIZE_SPECIAL_CHARS) : '*';
+// $SELECT = (isset($_GET['select'])) ? filter_input(INPUT_GET, 'select', FILTER_SANITIZE_SPECIAL_CHARS) : '*';
+$SELECT = (isset($_GET['select'])) ? $_GET['select'] : '*';
 
 if (!in_array($SELECT, $select_valids)) {
     $SELECT = '*';
 };
+
+if (isset($_GET['select']) && strtolower($_GET['select']) == 'count(*)') {
+    $SELECT = 'COUNT(*) as count';
+}
 
 // load endpoint_params.json
 $endpoint_params_tab = json_decode(file_get_contents(__DIR__ . '/../endpoint_params.json'), true);

--- a/public_html/api/api_cod/request.php
+++ b/public_html/api/api_cod/request.php
@@ -19,6 +19,7 @@ use function API\Helps\add_li_params;
 use function API\Helps\add_group;
 use function API\Helps\add_order;
 use function API\Helps\add_limit;
+use function API\Helps\add_offset;
 use function API\Qids\qids_qua;
 use function API\Leaderboard\leaderboard_table_format;
 use function API\Status\make_status_query;
@@ -424,11 +425,13 @@ if ($results === [] && ($qua !== "" || $query !== "")) {
     $results_tab = [];
     if ($query !== "") {
         $query = add_limit($query);
+        $query = add_offset($query);
         // apply $params to $qua
         $qua = sprintf(str_replace('?', "'%s'", $query), ...$params);
         $results_tab = fetch_query_new($query, $params, $get);
     } else {
         $qua = add_limit($qua);
+        $qua = add_offset($qua);
         $results_tab = fetch_query_new($qua, [], $get);
     }
     // ---

--- a/public_html/api/endpoint_params.json
+++ b/public_html/api/endpoint_params.json
@@ -58,6 +58,7 @@
             { "name": "pupdate", "column": "p.pupdate", "type": "pupdate", "placeholder": "Date of publication" },
             { "name": "add_date", "column": "p.add_date", "type": "text", "placeholder": "Date of addition to DB" },
             { "name": "limit", "column": "p.limit", "type": "number", "placeholder": "Limit results", "value": "50", "no_select": true },
+            { "name": "offset", "column": "p.offset", "type": "number", "placeholder": "Offset results", "value": "0", "no_select": true },
             { "name": "year", "column": "YEAR(p.pupdate)", "type": "number", "placeholder": "year of date" },
             { "name": "YEAR(date)", "column": "YEAR(p.date)", "type": "number", "placeholder": "year of date" },
             { "name": "select", "column": "select", "type": "text", "placeholder": "Select fields", "no_select": true },
@@ -80,6 +81,7 @@
             { "name": "add_date", "column": "add_date", "type": "text", "placeholder": "Date of addition to DB" },
             { "name": "group", "column": "group", "type": "text", "placeholder": "Group by field", "no_select": true },
             { "name": "limit", "column": "limit", "type": "number", "placeholder": "Limit results", "value": "50", "no_select": true },
+            { "name": "offset", "column": "p.offset", "type": "number", "placeholder": "Offset results", "value": "0", "no_select": true },
             { "name": "select", "column": "select", "type": "text", "placeholder": "Select fields", "no_select": true },
             { "name": "distinct", "column": "distinct", "type": "switch", "no_select": true}
         ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the "offset" parameter in the "pages" and "pages_users" API endpoints, allowing users to skip a specified number of results in paginated queries.

- **Improvements**
  - Enhanced handling of "limit" and "offset" parameters in API queries to ensure proper validation and prevent duplicate clauses.
  - Improved error reporting and file path handling in the key generation script for better transparency and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->